### PR TITLE
fake#betapdf(0.2, 0.4) hangs on Vim 8.0 with 64-bit integers

### DIFF
--- a/autoload/fake.vim
+++ b/autoload/fake.vim
@@ -66,7 +66,7 @@ let s:Random = {
 
 function! s:Random.randombits() abort  "{{{1
     let hash = sha256(self._r)
-    let self._r = abs(str2nr(hash, 16))
+    let self._r = abs(str2nr(hash[0:7], 16))
     
     if empty(self.RAND_MAX)
         let rand_max = '7fffffff'  " Int32


### PR DESCRIPTION
I noticed a regression with Vim version 8.0, which uses 64-bit integers instead of 32-bit. A call to `fake#betapdf()` would just hang; the function is looping endlessly because now `p` evaluates to a very large value, not something between 0 and 1. In `s:Random.randombits()`, the conversion of the SHA256 hash into a number now results in a 64-bit integer, but the `self.RAND_MAX` still is (32-bit) `0x7fffffff`. I suppose the initialization loop for `RAND_MAX` now aborts too soon. In general, the check of `str2nr(rand_max, 16) < 0` doesn't seem to work; it will never be `< 0` (on 64-bit), not for `0x7fffffffffffffff`, not for even larger values.

Instead, I fixed the problem by restricting the SHA256 hash value to the first 8 digits, i.e. a 32-bit range, so that `_r` fits inside `RAND_MAX` again.