### PR TITLE
ENH: Add fake#get_keynames(), useful e.g. for writing custom completions

### DIFF
--- a/autoload/fake.vim
+++ b/autoload/fake.vim
@@ -224,6 +224,16 @@ function! fake#has_keyname(keyname) abort  "{{{1
 endfunction
 "}}}1
 
+function! fake#get_keynames() abort  "{{{1
+    let in_memory_keys = keys(s:fake_codes) + keys(s:fake_cache)
+
+    let files = filter(split(globpath(s:srcpath, '*')), 's:path_isfile(v:val)')
+    let file_keys = map(files, 'fnamemodify(v:val, ":t")')
+
+    return uniq(sort(in_memory_keys + file_keys))
+endfunction
+"}}}1
+
 function! fake#gen(keyname) abort  "{{{1
     if has_key(s:fake_codes, a:keyname)
         return eval(s:fake_codes[a:keyname])


### PR DESCRIPTION
As s:fake_codes and s:fake_cache are script-local, we cannot access them from outside, but the information therein is necessary to obtain a list of all possible fake data sources, e.g. when writing a custom completion function for a :command that takes a fake data source.
Add fake#get_keynames(), with an implementation that somewhat mirrors fake#has_keyname().